### PR TITLE
bug: Fix mutual exclusivity between name and file

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,8 +101,8 @@ def tts_batch(text_speaker: str = 'en_us_002', req_text: str = 'TikTok Text to S
 
     print(f"\n{msg.capitalize()}")
 
-def batch_create():
-    out = open('voice.mp3', 'wb')
+def batch_create(filename: str = 'voice.mp3'):
+    out = open(filename, 'wb')
     
     for item in os.listdir('./batch/'):
         filestuff = open('./batch/' + item, 'rb').read()
@@ -156,7 +156,7 @@ def main():
         for i, item in enumerate(textlist):
             tts_batch(text_speaker, item, f'./batch/{i}.mp3')
         
-        batch_create()
+        batch_create(filename)
 
         for item in os.listdir('./batch/'):
             os.remove('./batch/' + item)


### PR DESCRIPTION
This resolves the state where a user has supplied the `--file`/`-f`
and also the `--name`/`-n` command line options.

Previously if `--file` was supplied the code path would use the
`batch_create()` function which was hard coded to use the filename
`voice.mp3`.  This re-works the definition of `batch_create()` to both
use an annotated argument as well as updating calls to supply the
filename argument.