### PR TITLE
tweak: use textwrap to split input text on words rather than in the middle of them

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import requests, base64, random, argparse, os, playsound, time, re
+import requests, base64, random, argparse, os, playsound, time, re, textwrap
 
 # https://twitter.com/scanlime/status/1512598559769702406
 
@@ -155,10 +155,8 @@ def main():
         filename = 'voice.mp3'
 
     if args.file is not None:
-        chunks, chunk_size = len(req_text), 200
-        textlist = [ req_text[i:i+chunk_size] for i in range(0, chunks, chunk_size)]
-
-        amount = len(textlist) 
+        chunk_size = 200
+        textlist = textwrap.wrap(req_text, width=chunk_size, break_long_words=True, break_on_hyphens=False)
 
         os.makedirs('./batch/')
 


### PR DESCRIPTION
Instead of blindly splitting the segments of a batch at every 200 characters which usually ended up splitting a word in half, segments are now, where possible, split at the closest word using Python's included text wrapping algorithm.
This results in better output for longer input strings as you don't get a word every 20 seconds of speech being pronounced in a *b- r- oken* way by the TTS engine.